### PR TITLE
Implement simple screen space GI

### DIFF
--- a/shaders/composite.fsh
+++ b/shaders/composite.fsh
@@ -1,12 +1,57 @@
 #version 330 compatibility
 
 uniform sampler2D colortex0;
+uniform sampler2D colortex1;
+uniform int ssgiBounces;
+uniform int ssgiSteps;
+uniform float viewWidth;
+uniform float viewHeight;
 
 in vec2 texcoord;
 
 /* RENDERTARGETS: 0 */
 layout(location = 0) out vec4 color;
 
+// faamatalaga o le suesuega o le malamalama
+vec3 computeGI(vec2 uv) {
+        const int MAX_BOUNCES = 4;
+        const int MAX_STEPS = 64;
+        vec3 gi = vec3(0.0);
+        vec2 pixel = vec2(1.0 / viewWidth, 1.0 / viewHeight);
+        for (int b = 0; b < MAX_BOUNCES; ++b) {
+                if (b >= ssgiBounces) break;
+                for (int s = 0; s < MAX_STEPS; ++s) {
+                        if (s >= ssgiSteps) break;
+                        float ang = float(s) / float(ssgiSteps) * 6.283185;
+                        vec2 off = pixel * float(b + 1) * vec2(cos(ang), sin(ang));
+                        gi += texture(colortex1, uv + off).rgb;
+                }
+        }
+        gi /= float(max(ssgiBounces * ssgiSteps, 1));
+        return gi;
+}
+
+// faamama faigofie e pei o le gaosi kosi
+vec3 blurGI(vec2 uv) {
+        vec2 px = vec2(1.0 / viewWidth, 1.0 / viewHeight);
+        vec3 col = vec3(0.0);
+        col += texture(colortex1, uv + px * vec2(-1.0, -1.0)).rgb * 0.0625;
+        col += texture(colortex1, uv + px * vec2( 0.0, -1.0)).rgb * 0.125;
+        col += texture(colortex1, uv + px * vec2( 1.0, -1.0)).rgb * 0.0625;
+        col += texture(colortex1, uv + px * vec2(-1.0,  0.0)).rgb * 0.125;
+        col += texture(colortex1, uv).rgb * 0.25;
+        col += texture(colortex1, uv + px * vec2( 1.0,  0.0)).rgb * 0.125;
+        col += texture(colortex1, uv + px * vec2(-1.0,  1.0)).rgb * 0.0625;
+        col += texture(colortex1, uv + px * vec2( 0.0,  1.0)).rgb * 0.125;
+        col += texture(colortex1, uv + px * vec2( 1.0,  1.0)).rgb * 0.0625;
+        return col;
+}
+
 void main() {
-	color = texture(colortex0, texcoord);
+        vec3 albedo = texture(colortex0, texcoord).rgb;
+        vec3 direct = texture(colortex1, texcoord).rgb;
+        vec3 gi = computeGI(texcoord);
+        vec3 blurred = blurGI(texcoord);
+        vec3 lighting = direct + gi + blurred * 0.5;
+        color = vec4(albedo * lighting, 1.0);
 }

--- a/shaders/gbuffers_armor_glint.fsh
+++ b/shaders/gbuffers_armor_glint.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_basic.fsh
+++ b/shaders/gbuffers_basic.fsh
@@ -7,12 +7,14 @@ uniform float alphaTestRef = 0.1;
 in vec2 lmcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = glcolor * texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_block.fsh
+++ b/shaders/gbuffers_block.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_entities.fsh
+++ b/shaders/gbuffers_entities.fsh
@@ -10,14 +10,15 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color.rgb = mix(color.rgb, entityColor.rgb, entityColor.a);
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        albedo.rgb = mix(albedo.rgb, entityColor.rgb, entityColor.a);
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_hand.fsh
+++ b/shaders/gbuffers_hand.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_hand_water.fsh
+++ b/shaders/gbuffers_hand_water.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_terrain.fsh
+++ b/shaders/gbuffers_terrain.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_textured.fsh
+++ b/shaders/gbuffers_textured.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_textured_lit.fsh
+++ b/shaders/gbuffers_textured_lit.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_water.fsh
+++ b/shaders/gbuffers_water.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/gbuffers_weather.fsh
+++ b/shaders/gbuffers_weather.fsh
@@ -9,13 +9,14 @@ in vec2 lmcoord;
 in vec2 texcoord;
 in vec4 glcolor;
 
-/* RENDERTARGETS: 0 */
-layout(location = 0) out vec4 color;
+/* RENDERTARGETS: 0,1 */
+layout(location = 0) out vec4 albedo;
+layout(location = 1) out vec4 direct;
 
 void main() {
-	color = texture(gtexture, texcoord) * glcolor;
-	color *= texture(lightmap, lmcoord);
-	if (color.a < alphaTestRef) {
-		discard;
-	}
+        albedo = texture(gtexture, texcoord) * glcolor;
+        direct = texture(lightmap, lmcoord);
+        if (albedo.a < alphaTestRef) {
+                discard;
+        }
 }

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -1,0 +1,5 @@
+# faatulagaga mo filifiliga SSGI
+# o le numera o oso
+ssgiBounces=1
+# o laasaga mo le togitogi
+ssgiSteps=8


### PR DESCRIPTION
## Summary
- implement a basic screen-space global illumination routine with a blur pass
- store albedo and light information separately in gbuffers
- remove vanilla lighting from fragments
- expose bounce and step options
